### PR TITLE
FIX: Multiple Content Files

### DIFF
--- a/Monofoxe/Monofoxe.Engine/ResourceInfoMgr.cs
+++ b/Monofoxe/Monofoxe.Engine/ResourceInfoMgr.cs
@@ -25,11 +25,19 @@ namespace Monofoxe.Engine
 
 		internal static void Init()
 		{
-			try
+			var assets = new List<string>();
+			var contentFiles = Directory.GetFiles(Path.GetFullPath(ContentDir), "Content*");
+			foreach (var contentFile in contentFiles)
 			{
-				_assetPaths = GameMgr.Game.Content.Load<string[]>("Content");
+				try
+				{
+					var content = Path.GetFileNameWithoutExtension(contentFile);
+					assets.AddRange(GameMgr.Game.Content.Load<string[]>(content));
+				}
+				catch { continue; }
 			}
-			catch (Exception) { }
+			Array.Resize(ref _assetPaths, assets.Count);
+			assets.CopyTo(_assetPaths);
 		}
 
 


### PR DESCRIPTION
Loading asset paths from all content files in the content directory and not just from the one called "Content".

Without this PR it isn't possible to load assets via resource boxes if the assets you want to load are coming from a content file different to the "Content.xnb".

Since Nopipeline supports multiple content files as well, it seems to be legit to support it in Monofoxe as well.